### PR TITLE
Propose a shorter  stack quick start guide

### DIFF
--- a/src/HL/View/Downloads.hs
+++ b/src/HL/View/Downloads.hs
@@ -20,7 +20,7 @@ stackSection url = do
     "You may also choose an installer package, which includes GHC and build tools."
 
   ul_ $ do
-    li_ $ (a_ [href_ "https://github.com/commercialhaskell/stack/blob/master/doc/GUIDE.md"] "Read the stack guide →")
+    li_ $ (a_ [href_ "https://github.com/yogsototh/stack/blob/master/doc/QUICKSTART.md"] "Read the stack guide →")
     li_ $ a_ [href_ "#choosing"] "Help me choose the right download →"
 
   h2_ [id_ "download-stack"] "Download stack"


### PR DESCRIPTION
I though the Guide was a bit overwhelming for a beginner. I propose to link to a quick start document pointing to the full stack guide.

nb. the link point to my forked repository if this is accepted, one must not forget to point to the commercialhaskell/stack repository.
